### PR TITLE
refactor(target): added second var to remove specific options

### DIFF
--- a/modules/target/ox_target/client.lua
+++ b/modules/target/ox_target/client.lua
@@ -80,8 +80,9 @@ end
 
 ---This will remove the target options from a local entity. This is useful for when you want to remove target options from a specific entity.
 ---@param entity any
-Target.RemoveLocalEntity = function(entity)
-    ox_target:removeLocalEntity(entity)
+---@param labels string | table | nil
+Target.RemoveLocalEntity = function(entities, optionNames)
+    ox_target:removeLocalEntity(entities, optionNames)
 end
 
 ---This will add target options to all specified models. This is useful for when you want to add target options to all models of a specific type.

--- a/modules/target/qb-target/client.lua
+++ b/modules/target/qb-target/client.lua
@@ -89,9 +89,10 @@ Target.AddLocalEntity = function(entities, options)
 end
 
 ---This will remove the target options from a local entity. This is useful for when you want to remove target options from a specific entity.
----@param entity any
-Target.RemoveLocalEntity = function(entity)
-    qb_target:RemoveTargetEntity(entity)
+---@param entity number | table
+---@param labels string | table | nil
+Target.RemoveLocalEntity = function(entity, labels)
+    qb_target:RemoveTargetEntity(entity, labels)
 end
 
 ---This will add target options to all specified models. This is useful for when you want to add target options to all models of a specific type.

--- a/modules/target/sleepless_interact/client.lua
+++ b/modules/target/sleepless_interact/client.lua
@@ -104,9 +104,10 @@ end
 
 ---comment
 ---@param entity number
+---@param labels string | table | nil
 ---@return nil
-Target.RemoveLocalEntity = function(entity)
-    sleepless_interact:removeLocalEntity(entity)
+Target.RemoveLocalEntity = function(entity, labels)
+    sleepless_interact:removeLocalEntity(entity, labels)
 end
 
 ---comment


### PR DESCRIPTION
## Pull Request Checklist

- [X ] PR is targeting the `dev` branch
- [ ] I have pulled the latest changes from `dev` and resolved any merge conflicts
- [X ] My code follows the project’s style guidelines
- [X ] I have tested my changes and ensured they work as expected
- [ X] Relevant documentation/comments have been added or updated
- [ ] Any dependent changes have been merged

## Description

This PR aims to allow the user to remove only specific options of target local entities. 
This way users can remove only a specific option or options of their entity/entities. Although there
are diferences on how to use it, all 3 targets use and allow these specifications

## Related Issues

N/A

## Testing Steps

Create a target for a local entity.
Try and remove a specific option by giving the label or name (depending if ox/sleepless or qb)
Great success

## Additional Notes
N/A
