### PR TITLE
fix(fuel): fixed currentFuel nil error

### DIFF
--- a/modules/fuel/ox_fuel/client.lua
+++ b/modules/fuel/ox_fuel/client.lua
@@ -24,7 +24,7 @@ end
 Fuel.SetFuel = function(vehicle, fuel, type)
     if not DoesEntityExist(vehicle) then return end
     local currentFuel = Entity(vehicle).state.fuel
-    Entity(vehicle).state.fuel = currentFuel + fuel
+    Entity(vehicle).state.fuel = currentFuel and currentFuel + fuel or fuel
     return Entity(vehicle).state.fuel
 end
 


### PR DESCRIPTION
## Pull Request Checklist

- [X] PR is targeting the `dev` branch
- [X] I have pulled the latest changes from `dev` and resolved any merge conflicts
- [X] My code follows the project’s style guidelines
- [X] I have tested my changes and ensured they work as expected
- [X] Relevant documentation/comments have been added or updated
- [X] Any dependent changes have been merged

## Description

I get an error when I try to use the set fuel operation in ox fuel, the currentFuel definition appears as nil

![Screenshot 2025-06-08 194113](https://github.com/user-attachments/assets/750c025c-2b4e-4d61-9bd2-fd40dfdb13f5)