### PR TITLE
feat(modules): add origen_police to dispatch modules

### DIFF
--- a/modules/dispatch/origen_police/client/client.lua
+++ b/modules/dispatch/origen_police/client/client.lua
@@ -1,0 +1,22 @@
+---@diagnostic disable: duplicate-set-field
+if GetResourceState('origen_police') == 'missing' then return end
+Dispatch = Dispatch or {}
+
+Dispatch.SendAlert = function(data)
+    local customData = {
+        coords = data.coords or vector3(0.0, 0.0, 0.0),
+        title = 'Alert '..(data.code or '10-80'),
+        message = data.message,
+        job = data.jobs or 'police',
+        metadata = {
+            model = data.vehicle and (GetDisplayNameFromVehicleModel(GetEntityModel(data.vehicle))) or nil,
+            color = {255, 255, 255},
+            plate = data.vehicle and GetVehicleNumberPlateText(data.vehicle) or nil,
+            speed = data.vehicle and (GetEntitySpeed(veh) * 3.6)..' kmh' or nil
+        }
+    }
+
+    TriggerServerEvent("SendAlert:police", customData)
+end
+
+return Dispatch

--- a/modules/dispatch/origen_police/client/client.lua
+++ b/modules/dispatch/origen_police/client/client.lua
@@ -3,6 +3,11 @@ if GetResourceState('origen_police') == 'missing' then return end
 Dispatch = Dispatch or {}
 
 Dispatch.SendAlert = function(data)
+    local color = nil
+    if data.vehicle then
+        local r, g, b = GetVehicleColor(data.vehicle)
+        color = {r, g, b}
+    end
     local customData = {
         coords = data.coords or vector3(0.0, 0.0, 0.0),
         title = 'Alert '..(data.code or '10-80'),
@@ -10,7 +15,7 @@ Dispatch.SendAlert = function(data)
         job = data.jobs or 'police',
         metadata = {
             model = data.vehicle and (GetDisplayNameFromVehicleModel(GetEntityModel(data.vehicle))) or nil,
-            color = {255, 255, 255},
+            color = color,
             plate = data.vehicle and GetVehicleNumberPlateText(data.vehicle) or nil,
             speed = data.vehicle and (GetEntitySpeed(veh) * 3.6)..' kmh' or nil
         }

--- a/modules/dispatch/origen_police/server/server.lua
+++ b/modules/dispatch/origen_police/server/server.lua
@@ -1,0 +1,4 @@
+if GetResourceState('origen_police') == 'missing' then return end
+Dispatch = Dispatch or {}
+
+return Dispatch


### PR DESCRIPTION
## Pull Request Checklist

- [x] PR is targeting the `dev` branch
- [ ] I have pulled the latest changes from `dev` and resolved any merge conflicts
- [x] My code follows the project’s style guidelines
- [x] I have tested my changes and ensured they work as expected
- [ ] Relevant documentation/comments have been added or updated
- [ ] Any dependent changes have been merged

### Resource Relevance and Usage
- [x] Resource is active on 100+ servers, OR
- [ ] Resource has a verifiable dependency on community_bridge, OR
- [ ] Exception justified (adds value or supports project goals)

### Avoiding Breaking Changes
- [x] No breaking changes introduced, OR
- [ ] If deprecating: 2-4 month grace period provided
- [ ] Deprecation notices clearly documented in code with dates

### Documentation and Testing
- [ ] At least one usage example included.
- [ ] IntelliSense-style comments added.
- [ ] Unit test coverage provided

## Description
Added origen_police to dispatch modules.

## Related Issues
NaN

## Testing Steps
Register a command to test the implementation:
```lua
RegisterCommand("dispatch", function()
    local ped = PlayerPedId()
    local vehicle = GetVehiclePedIsIn(ped, false)
    if not vehicle or vehicle == 0 then
        vehicle = nil
    end
    local data = {
        vehicle = vehicle or nil,
        plate = vehicle and GetVehicleNumberPlateText(vehicle) or nil,
        ped = ped,
        pedCoords = ped and GetEntityCoords(ped),
        coords = GetEntityCoords(ped),
        blipData = {
            sprite = 161,
            color = 1,
            scale = 0.8,
        },
        message = "Vehicle is being stolen",
        code = '10-80',
        icon = 'fas fa-question',
        jobs = {'police'},
        alertTime = 10
    }

    -- The above is an exmaple but covers all supported keys

    Bridge.Dispatch.SendAlert(data)
end)
```
![image](https://github.com/user-attachments/assets/13e7cf60-979a-4743-8e0d-bd1206815fc3)


## Additional Notes
I made two commits, so if it's necessary I can squash them.