### PR TITLE
Dev

### DIFF
--- a/modules/target/qb-target/client.lua
+++ b/modules/target/qb-target/client.lua
@@ -61,7 +61,10 @@ end
 ---@param options table
 Target.AddGlobalPed = function(options)
     options = Target.FixOptions(options)
-    qb_target:AddGlobalPed(options)
+    qb_target:AddGlobalPed({
+        options = options,
+        distance = options.distance or 1.5
+    })
 end
 
 ---This will remove target options from all peds. This is useful for when you want to remove target options from all peds.


### PR DESCRIPTION
## Pull Request Checklist

- [X] PR is targeting the `dev` branch
- [X] I have pulled the latest changes from `dev` and resolved any merge conflicts
- [X] My code follows the project’s style guidelines
- [X] I have tested my changes and ensured they work as expected
- [X] Relevant documentation/comments have been added or updated
- [X] Any dependent changes have been merged

### Resource Relevance and Usage
- [ ] Resource is active on 100+ servers, OR
- [ ] Resource has a verifiable dependency on community_bridge, OR
- [X] Exception justified (adds value or supports project goals)

### Avoiding Breaking Changes
- [X] No breaking changes introduced, OR
- [ ] If deprecating: 2-4 month grace period provided
- [ ] Deprecation notices clearly documented in code with dates

### Documentation and Testing
- [ ] At least one usage example included.
- [ ] IntelliSense-style comments added.
- [ ] Unit test coverage provided

## Description
This PR fixes an error within the `community_bridge` when adding global ped targets via `qb-target`. The error, "bad argument #1 to 'for iterator' (table expected, got nil)," occurred because the Target.AddGlobalPed function was incorrectly formatting the parameters.

`qb-target` expects a table with options and distance properties, but community_bridge was passing the options directly. This caused the SetOptions function to receive nil, leading to the error.

I've updated the Target.AddGlobalPed function to properly wrap the options, ensuring the parameters are passed in the correct format. This now matches the structure used by other working functions in the file, like AddGlobalPlayer and AddGlobalVehicle.

## Related Issues
There are no related issues

## Testing Steps
I created a target using AddGlobalPed and verified that it worked

## Additional Notes
No additional notes. This is my first pull request....ever. Give me a cookie.