### PR TITLE
Fix typo "platerData" to "playerData"

### DIFF
--- a/modules/framework/qbx_core/client.lua
+++ b/modules/framework/qbx_core/client.lua
@@ -168,8 +168,8 @@ end
 ---This will get a players dead status.
 ---@return boolean
 Framework.GetIsPlayerDead = function()
-    local platerData = Framework.GetPlayerData()
-    return platerData.metadata["isdead"] or platerData.metadata["inlaststand"]
+    local playerData = Framework.GetPlayerData()
+    return playerData.metadata["isdead"] or playerData.metadata["inlaststand"]
 end
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()


### PR DESCRIPTION
## Pull Request Checklist

- [x] PR is targeting the `dev` branch
- [x] I have pulled the latest changes from `dev` and resolved any merge conflicts
- [x] My code follows the project’s style guidelines
- [x] I have tested my changes and ensured they work as expected
- [x] Relevant documentation/comments have been added or updated
- [x] Any dependent changes have been merged

### Resource Relevance and Usage
- [x] Resource is active on 100+ servers, OR
- [x] Resource has a verifiable dependency on community_bridge, OR
- [x] Exception justified (adds value or supports project goals)

### Avoiding Breaking Changes
- [x] No breaking changes introduced, OR
- [x] If deprecating: 2-4 month grace period provided
- [x] Deprecation notices clearly documented in code with dates

### Documentation and Testing
- [x] At least one usage example included.
- [x] IntelliSense-style comments added.
- [x] Unit test coverage provided

## Description

In this PR I have amended lines 171-172 in the `modules/framework/qbx_core/client.lua` where I have spotted a small typo "platerData" instead of "playerData".

## Related Issues

N/A

## Testing Steps

### Branch
1. Started resource on my QBox development server
2. Triggered the event and no errors have occurred

## Additional Notes

N/A