### PR TITLE
Fix issue with GetThirst and GetHunger not working in ESX

### DIFF
--- a/modules/framework/es_extended/server.lua
+++ b/modules/framework/es_extended/server.lua
@@ -257,7 +257,7 @@ Framework.GetHunger = function(src)
 
     for _, entry in ipairs(status) do
         if entry.name == "hunger" then
-            return entry.percent
+            return math.floor(entry.percent)
         end
     end
 end
@@ -271,7 +271,7 @@ Framework.GetThirst = function(src)
 
     for _, entry in ipairs(status) do
         if entry.name == "thirst" then
-            return entry.percent
+            return math.floor(entry.percent)
         end
     end
 end


### PR DESCRIPTION
## Pull Request Checklist

- [x] PR is targeting the `dev` branch
- [x] I have pulled the latest changes from `dev` and resolved any merge conflicts
- [x] My code follows the project’s style guidelines
- [x] I have tested my changes and ensured they work as expected
- [x] Relevant documentation/comments have been added or updated
- [x] Any dependent changes have been merged

## Description

I tried getting the thirst and hunger server side with the Bridge and those methods do not work. due to the data structure of status in ESX.

**Status Column Data Structure**
```json
[
    {
        "val": 0,
        "percent": 0.0,
        "name": "drunk"
    },
    {
        "val": 214100,
        "percent": 21.41,
        "name": "hunger"
    },
    {
        "val": 285575,
        "percent": 28.5575,
        "name": "thirst"
    }
]
```

Before we were accessing the status column with `Framework.GetStatus(src, "status")` and then trying to access hunger or thirst with the dot notation `status.hunger`. This will not work due to the data structure above where each status is it's own table.

I decided to retrieve the percent value as the other two main frameworks qb-core and qbox also return the percent value.

## Testing Steps

1. Trigger these functions in a server sided event and ensure we are getting the hunger and thirst back as a percentage
<img width="778" height="30" alt="image" src="https://github.com/user-attachments/assets/2a3bdc08-dac5-4584-89eb-1380d7777aac" />