### PR TITLE
Added missing command registration support for the Qbox framework module.

### DIFF
--- a/modules/framework/qbx_core/server.lua
+++ b/modules/framework/qbx_core/server.lua
@@ -579,5 +579,3 @@ Framework.Commands.Add = function(name, help, arguments, argsrequired, callback,
 end
 
 return Framework
-
-return Framework

--- a/modules/framework/qbx_core/server.lua
+++ b/modules/framework/qbx_core/server.lua
@@ -547,4 +547,37 @@ AddEventHandler("playerDropped", function()
     TriggerEvent("community_bridge:Server:OnPlayerUnload", src)
 end)
 
+AddEventHandler("playerDropped", function()
+    local src = source
+    TriggerEvent("community_bridge:Server:OnPlayerUnload", src)
+end)
+
+Framework.Commands = Framework.Commands or {}
+
+---@description Adds a command to the Qbox framework
+---@param name string
+---@param help string
+---@param arguments table
+---@param argsrequired boolean
+---@param callback function
+---@param permission string
+---@param ... any
+Framework.Commands.Add = function(name, help, arguments, argsrequired, callback, permission, ...)
+    lib.addCommand(name, {
+        help = help or "",
+        params = arguments or {},
+        restricted = false
+    }, function(source, args, raw)
+        if permission and permission ~= "user" then
+            if not Framework.GetIsFrameworkAdmin(source) then
+                return
+            end
+        end
+
+        callback(source, args or {}, raw)
+    end)
+end
+
+return Framework
+
 return Framework

--- a/modules/framework/qbx_core/server.lua
+++ b/modules/framework/qbx_core/server.lua
@@ -547,11 +547,6 @@ AddEventHandler("playerDropped", function()
     TriggerEvent("community_bridge:Server:OnPlayerUnload", src)
 end)
 
-AddEventHandler("playerDropped", function()
-    local src = source
-    TriggerEvent("community_bridge:Server:OnPlayerUnload", src)
-end)
-
 Framework.Commands = Framework.Commands or {}
 
 ---@description Adds a command to the Qbox framework


### PR DESCRIPTION
## Description

Added missing command registration support for the Qbox framework module.

The ESX and QBCore framework modules already expose `Framework.Commands.Add`, but the Qbox module did not define `Framework.Commands`, causing resources that rely on the unified Community Bridge command API to fail on Qbox with:

```txt
attempt to index a nil value (field 'Commands')
```

This PR adds `Framework.Commands.Add` to the Qbox server framework module using `lib.addCommand`, while preserving the same public bridge API used by the other framework modules.

Admin-restricted commands are checked through the existing Qbox bridge admin resolver:

```lua
Framework.GetIsFrameworkAdmin(source)
```

This keeps command registration consistent across the different frameworks

## Testing Steps

1. Started a server using Qbox with Community Bridge.
2. Loaded a resource that registers commands through:

```lua
Bridge.Framework.Commands.Add(name, help, arguments, argsrequired, callback, permission)
```

3. Confirmed that the resource no longer fails during initialization with `field 'Commands'` being nil.
4. Tested a user command with `permission = "user"` and confirmed it executes successfully.
5. Tested an admin command with `permission = "admin"` and confirmed it only executes when `Framework.GetIsFrameworkAdmin(source)` returns true.
6. Confirmed existing ESX and QBCore behavior is not affected because the change only applies to the Qbox framework module.

## Additional Notes

This change aligns the Qbox framework module with the existing ESX and QBCore bridge structure by exposing the same `Framework.Commands.Add` API.

The implementation uses `lib.addCommand`, which is already available through Community Bridge’s ox_lib dependency.