### PR TITLE
GetInvokingResource target index fix

### DIFF
--- a/lib/logs/server/logs.lua
+++ b/lib/logs/server/logs.lua
@@ -74,11 +74,11 @@ local logHandlers = {
     end,
 
     qb = function(message)
-        TriggerEvent('qb-log:server:CreateLog', GetCurrentResourceName(), GetInvokingResource(), 'green', message, false)
+        TriggerEvent('qb-log:server:CreateLog', GetCurrentResourceName(), GetInvokingResource() or GetCurrentResourceName(), 'green', message, false)
     end,
 
     ox_lib = function(message)
-        lib.logger(GetInvokingResource(), GetCurrentResourceName(), message)
+        lib.logger(GetInvokingResource() or GetCurrentResourceName(), GetCurrentResourceName(), message)
     end,
 
     ['built-in'] = function(message)

--- a/modules/target/ox_target/client.lua
+++ b/modules/target/ox_target/client.lua
@@ -22,7 +22,7 @@ end
 function Target.FixOptions(options)
     for _, v in pairs(options) do
         local action = v.onSelect or v.action
-        if not action then 
+        if not action then
             local _type = v.type
             if _type and _type == "server" then
                 v.serverEvent = v.event
@@ -104,7 +104,7 @@ end
 function Target.AddLocalEntity(entities, options)
     options = Target.FixOptions(options)
     ox_target:addLocalEntity(entities, options)
-    local resource = GetInvokingResource() 
+    local resource = GetInvokingResource() or GetCurrentResourceName()
     resourceTargets.entities[resource] = resourceTargets.entities[resource] or {}
     table.insert(resourceTargets.entities[resource], { entities = entities})
 end
@@ -122,7 +122,7 @@ end
 function Target.AddNetworkedEntity(netids, options)
     options = Target.FixOptions(options)
     ox_target:addEntity(netids, options)
-    local resource = GetInvokingResource() 
+    local resource = GetInvokingResource() or GetCurrentResourceName()
     resourceTargets.networkedEntities[resource] = resourceTargets.networkedEntities[resource] or {}
     table.insert(resourceTargets.networkedEntities[resource], { netids = netids})
 end
@@ -140,7 +140,7 @@ end
 function Target.AddModel(models, options)
     options = Target.FixOptions(options)
     ox_target:addModel(models, options)
-    local resource = GetInvokingResource() 
+    local resource = GetInvokingResource() or GetCurrentResourceName()
     resourceTargets.models[resource] = resourceTargets.models[resource] or {}
     table.insert(resourceTargets.models[resource], { models = models})
 end
@@ -167,7 +167,7 @@ function Target.AddBoxZone(name, coords, size, heading, options, debug)
         debug = debug or targetDebug,
         options = options,
     })
-    table.insert(targetZones, { name = name, id = target, creator = GetInvokingResource() })
+    table.insert(targetZones, { name = name, id = target, creator = GetInvokingResource() or GetCurrentResourceName() })
     return target
 end
 
@@ -185,7 +185,7 @@ function Target.AddSphereZone(name, coords, radius, options, debug)
         debug = targetDebug or debug,
         options = options
     })
-    table.insert(targetZones, { name = name, id = target, creator = GetInvokingResource() })
+    table.insert(targetZones, { name = name, id = target, creator = GetInvokingResource() or GetCurrentResourceName() })
     return target
 end
 
@@ -216,7 +216,7 @@ AddEventHandler('onResourceStop', function(resource)
     end
     resourceTargets.entities[resource] = nil
     if resourceTargets.networkedEntities[resource] and #resourceTargets.networkedEntities[resource] > 0 then
-        for _, data in pairs(resourceTargets.networkedEntities[resource]) do        
+        for _, data in pairs(resourceTargets.networkedEntities[resource]) do
             Target.RemoveNetworkedEntity(data.netids)
         end
     end

--- a/modules/target/qb-target/client.lua
+++ b/modules/target/qb-target/client.lua
@@ -182,7 +182,7 @@ function Target.AddBoxZone(name, coords, size, heading, options, debug)
         options = options,
         distance = getLargestDistance(options),
     })
-    table.insert(targetZones, { name = name, creator = GetInvokingResource() })
+    table.insert(targetZones, { name = name, creator = GetInvokingResource() or GetCurrentResourceName() })
     return name
 end
 
@@ -200,7 +200,7 @@ function Target.AddSphereZone(name, coords, radius, options, debug)
         options = options,
         distance = getLargestDistance(options),
     })
-    table.insert(targetZones, { name = name, creator = GetInvokingResource() })
+    table.insert(targetZones, { name = name, creator = GetInvokingResource() or GetCurrentResourceName() })
     return name
 end
 

--- a/modules/target/sleepless_interact/client.lua
+++ b/modules/target/sleepless_interact/client.lua
@@ -27,8 +27,8 @@ function Target.FixOptions(options)
         end
         options[k].onSelect = select
         options[k].groups = v.job or v.groups
-        local optionsCanInteract = v.canInteract      
-        if optionsCanInteract then 
+        local optionsCanInteract = v.canInteract
+        if optionsCanInteract then
             local id = Target.CreateCanInteract(optionsCanInteract)
             v.canInteract = function(...)
                 return Target.CanInteract(id, ...)
@@ -142,7 +142,7 @@ function Target.AddBoxZone(name, coords, size, heading, options)
         coords = coords,
         options = options,
     })
-    table.insert(targetZones, { name = name, id = target, creator = GetInvokingResource() })
+    table.insert(targetZones, { name = name, id = target, creator = GetInvokingResource() or GetCurrentResourceName() })
     return target
 end
 
@@ -160,7 +160,7 @@ function Target.AddSphereZone(name, coords, radius, options, debug)
         debug = targetDebug or debug,
         options = options
     })
-    table.insert(targetZones, { name = name, id = target, creator = GetInvokingResource() })
+    table.insert(targetZones, { name = name, id = target, creator = GetInvokingResource() or GetCurrentResourceName() })
     return target
 end
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] PR is targeting the `dev` branch
- [x] I have pulled the latest changes from `dev` and resolved any merge conflicts
- [x] My code follows the project’s style guidelines
- [x] I have tested my changes and ensured they work as expected
- [na] Relevant documentation/comments have been added or updated
- [na] Any dependent changes have been merged

### Resource Relevance and Usage
- [ ] Resource is active on 100+ servers, OR
- [ ] Resource has a verifiable dependency on community_bridge, OR
- [x] Exception justified (adds value or supports project goals)

### Avoiding Breaking Changes
- [x] No breaking changes introduced, OR
- [ ] If deprecating: 2-4 month grace period provided
- [ ] Deprecation notices clearly documented in code with dates

### Documentation and Testing
- [ ] At least one usage example included.
- [ ] IntelliSense-style comments added.
- [ ] Unit test coverage provided

## Description
SCRIPT ERROR: @community_bridge/modules/target/ox_target/client.lua:108: table index is nil^7

Update to targets checking for invoking resource does not consider nill return from GetInvokingResource.
This breaks the target property implementation in lib/Entity as its itself calling the function.
Updated any thing using GetInvokingResource will the fallback of GetCurrentResourceName (aka community_bridge or the resource that required it). 

## Related Issues
Currently if target property is set on Entity.Create it breaks Entity+Points

## Testing Steps
Doesnt really need testing. Just a fallback. community_bridge starts and i no longer get the error

## Additional Notes

<!-- Add any other relevant information or context here -->